### PR TITLE
Preserve global variable dropdown selections after refresh

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -67,7 +67,18 @@ function loadStrategy(name){
   for(const k in globals_values) delete globals_values[k];
   const xml=strategies[name];
   if(xml){
-    try{ XML.domToWorkspace(XML.textToDom(xml),workspace);}
+    try{
+      // Pre-populate global keys so dropdowns keep selections after reload
+      const dom = XML.textToDom(xml);
+      Array.from(dom.getElementsByTagName('block')).forEach(b=>{
+        if(b.getAttribute('type')==='globals_values_create'){
+          const field = b.querySelector('field[name="KEY"]');
+          const key = field?.textContent;
+          if(key) globals_values[key] ??= undefined;
+        }
+      });
+      XML.domToWorkspace(dom,workspace);
+    }
     catch(e){ console.warn('Corrupted XML in strategy',name,e); }
   }
   refreshGlobalKeyDropdowns();


### PR DESCRIPTION
## Summary
- Ensure globals values dropdown retains selection after page reload by pre-populating keys before workspace load

## Testing
- `node --check js/main.js`
- `node --check js/blocks.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4844a2e548324bb4ed7bc397d374c