### PR TITLE
Add candlestick chart with indicators and trade markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <!-- Chart.js financial plugin -->
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-financial@3"></script>
 
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -88,7 +90,15 @@
         <canvas id="balanceChart" class="w-full h-80"></canvas>
       </div>
 
-      <!-- === 4. Logs (full-width) ===================================== -->
+      <!-- === 4. Candlestick chart (lazy-loaded) ====================== -->
+      <div class="col-span-12 bg-white p-6 rounded-2xl shadow space-y-4">
+        <button id="showCandleBtn" class="bg-blue-500 text-white px-3 py-1 rounded hidden">Show chart</button>
+        <div id="candleContainer" class="h-80 hidden">
+          <canvas id="candleChart" class="w-full h-full"></canvas>
+        </div>
+      </div>
+
+      <!-- === 5. Logs (full-width) ===================================== -->
       <div class="col-span-12 bg-white p-6 rounded-2xl shadow">
         <pre id="output"
              class="bg-gray-900 text-white p-4 rounded overflow-auto text-sm h-80"></pre>


### PR DESCRIPTION
## Summary
- Add Chart.js financial plugin and new candlestick chart panel with lazy loading
- Track indicator values and buy/sell points during simulation
- Render candlestick chart with indicators and trade markers on demand
- Destroy any existing candlestick chart before creating a new one to prevent canvas reuse errors
- Register Chart.js financial candlestick components and set candlestick chart type

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4813d556083249f8a1d222001d7e4