### PR TITLE
Register candlestick controller for Chart.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
 
   <!-- Chart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3"></script>
-  <!-- Chart.js financial plugin -->
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-financial@3"></script>
-
   <link rel="stylesheet" href="css/style.css">
 </head>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,17 @@
+import {
+  CandlestickController,
+  CandlestickElement,
+  OhlcController,
+  OhlcElement
+} from 'https://cdn.jsdelivr.net/npm/chartjs-chart-financial@3/dist/chartjs-chart-financial.esm.js';
+
+Chart.register(
+  CandlestickController,
+  CandlestickElement,
+  OhlcController,
+  OhlcElement
+);
+
 /* ---------- BLOCKLY INIT ------------------------------------------------- */
 const workspace = Blockly.inject('blocklyDiv', { toolbox });
 


### PR DESCRIPTION
## Summary
- Load Chart.js financial components via ES module import
- Register candlestick chart controllers before Blockly setup
- Drop redundant financial plugin script tag from HTML

## Testing
- `node --check js/main.js`
- `node -e "import('https://cdn.jsdelivr.net/npm/chartjs-chart-financial@3/dist/chartjs-chart-financial.esm.js').then(m=>console.log(Object.keys(m))).catch(e=>console.error('error',e));" 2>&1 | head -n 20` *(fails: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'https:')*

------
https://chatgpt.com/codex/tasks/task_e_68a492a43b7c8324bf3d40d58f06369c