### PR TITLE
Fix Chart.js module resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,15 @@
 
   <!-- PapaParse -->
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
-
-  <!-- Chart.js -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <!-- Import maps for Chart.js and the financial plugin -->
+  <script type="importmap">
+  {
+    "imports": {
+      "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.esm.js",
+      "chartjs-chart-financial": "https://cdn.jsdelivr.net/npm/chartjs-chart-financial@0.2.1/dist/chartjs-chart-financial.esm.js"
+    }
+  }
+  </script>
   <link rel="stylesheet" href="css/style.css">
 </head>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,9 +1,10 @@
+import { Chart } from 'chart.js';
 import {
   CandlestickController,
   OhlcController,
   FinancialElement,
   FinancialScale
-} from 'https://cdn.jsdelivr.net/npm/chartjs-chart-financial@0.2.1/dist/chartjs-chart-financial.esm.js';
+} from 'chartjs-chart-financial';
 
 Chart.register(CandlestickController, OhlcController, FinancialElement, FinancialScale);
 


### PR DESCRIPTION
## Summary
- load Chart.js and the financial plugin via import maps
- switch main module to ESM imports instead of CDN URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a13865288324a8490783c1675985