### PR TITLE
Render candlestick chart on CSV load

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -230,6 +230,7 @@ document.getElementById('csvFile').addEventListener('change',e=>{
         const t=new Date(row.Time).getTime();
         return !isNaN(t)&&[row.Open,row.High,row.Low,row.Close].every(v=>v!=null);
       });
+      renderChart();
     }
   });
 });


### PR DESCRIPTION
## Summary
- ensure candlestick chart renders automatically after CSV with OHLC data is loaded

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ba883dc8324ab9ebb20e824d321