### PR TITLE
Render candlestick chart on CSV load

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -210,7 +210,7 @@ function renderChart(){
   const data=csvData
     .filter(r=>{
       const t=new Date(r.Time).getTime();
-      return !isNaN(t)&&[r.Open,r.High,r.Low,r.Close].every(v=>v!=null);
+      return !isNaN(t)&&[r.Open,r.High,r.Low,r.Close].every(v=>v!=null&&!isNaN(v));
     })
     .map(r=>(
       {
@@ -228,8 +228,9 @@ document.getElementById('csvFile').addEventListener('change',e=>{
     complete:r=>{
       csvData=r.data.filter(row=>{
         const t=new Date(row.Time).getTime();
-        return !isNaN(t)&&[row.Open,row.High,row.Low,row.Close].every(v=>v!=null);
+        return !isNaN(t)&&[row.Open,row.High,row.Low,row.Close].every(v=>v!=null&&!isNaN(v));
       });
+      renderChart();
     }
   });
 });


### PR DESCRIPTION
## Summary
- ensure candlestick chart renders automatically after CSV with OHLC data is loaded
- validate OHLC rows to avoid `Value is null` errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ba883dc8324ab9ebb20e824d321